### PR TITLE
feat: Add noPlaceFound event to directive

### DIFF
--- a/src/lib/angular-google-place/directives/angular-google-place.directive.ts
+++ b/src/lib/angular-google-place/directives/angular-google-place.directive.ts
@@ -49,6 +49,8 @@ export class AngularGooglePlaceDirective implements OnInit {
   @Output() state: EventEmitter<any> = new EventEmitter();
   @Output() district: EventEmitter<any> = new EventEmitter();
 
+  @Output() noPlaceFound: EventEmitter<boolean> = new EventEmitter();
+
 
   /*
    NOT USED YET
@@ -121,6 +123,8 @@ export class AngularGooglePlaceDirective implements OnInit {
         this.place = this.autocomplete.getPlace();
         if (this.place && this.place.place_id) {
           this.invokeEvent();
+        } else {
+          this.noPlaceFound.emit(true);
         }
       });
     });


### PR DESCRIPTION
Add an output event emitted when the google place api has no event found to be able to handle this. It's useful in case the additional, originally hidden address fields should be shown in case no address is found.